### PR TITLE
Remove magic numbers from Python project

### DIFF
--- a/demo_plots.py
+++ b/demo_plots.py
@@ -9,18 +9,19 @@ import os
 # Add src directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
+from constants import DEFAULT_SUBJECT, DEFAULT_RUN, SEPARATOR_WIDTH_WIDE
 from preprocess import preprocess_subject
 from train import train_with_holdout
 
 
 def main():
     # Get subject and run from command line or use defaults
-    subject = int(sys.argv[1]) if len(sys.argv) > 1 else 4
-    run = int(sys.argv[2]) if len(sys.argv) > 2 else 14
+    subject = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_SUBJECT
+    run = int(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_RUN
 
-    print("=" * 70)
+    print("=" * SEPARATOR_WIDTH_WIDE)
     print("EEG BCI Visualization Demo")
-    print("=" * 70)
+    print("=" * SEPARATOR_WIDTH_WIDE)
     print(f"Subject: {subject}")
     print(f"Run: {run}")
     print()
@@ -48,9 +49,9 @@ def main():
     )
 
     print()
-    print("=" * 70)
+    print("=" * SEPARATOR_WIDTH_WIDE)
     print("RESULTS SUMMARY")
-    print("=" * 70)
+    print("=" * SEPARATOR_WIDTH_WIDE)
     print(f"Cross-validation mean: {cv_scores.mean():.4f} (+/- {cv_scores.std() * 2:.4f})")
     print(f"Test set accuracy: {test_accuracy:.4f}")
     print()
@@ -58,7 +59,7 @@ def main():
     print("  - plots/cv_scores_csp_lda_holdout.png")
     print("  - plots/confusion_matrix_csp_lda.png")
     print("  - plots/training_summary_csp_lda.png")
-    print("=" * 70)
+    print("=" * SEPARATOR_WIDTH_WIDE)
 
 
 if __name__ == "__main__":

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,24 +5,92 @@ This module centralizes magic numbers and configuration values
 used across multiple modules to ensure consistency and maintainability.
 """
 
-from typing import Final
+from typing import Final, Tuple
 
+# =============================================================================
 # Numerical stability
+# =============================================================================
 EPSILON: Final[float] = 1e-10
 EPSILON_SMALL: Final[float] = 1e-6
 
+# =============================================================================
 # Random seed for reproducibility
+# =============================================================================
 RANDOM_STATE: Final[int] = 42
 
-# Subject constraints (Physionet EEGMMIDB dataset)
+# =============================================================================
+# Physionet EEGMMIDB dataset constraints
+# =============================================================================
 MIN_SUBJECT: Final[int] = 1
 MAX_SUBJECT: Final[int] = 109
 
 # Valid run numbers for the dataset
 VALID_RUNS: Final[tuple] = (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
 
-# Performance target
+# Default values for demo/testing
+DEFAULT_SUBJECT: Final[int] = 4
+DEFAULT_RUN: Final[int] = 14
+
+# =============================================================================
+# EEG Signal Processing
+# =============================================================================
+# Sampling rate for Physionet EEGMMIDB dataset (Hz)
+EEG_SAMPLING_RATE: Final[float] = 160.0
+
+# Bandpass filter cutoff frequencies (Hz)
+EEG_BANDPASS_LOW: Final[float] = 7.0
+EEG_BANDPASS_HIGH: Final[float] = 30.0
+
+# Welch PSD method parameters
+WELCH_NPERSEG: Final[int] = 256
+WELCH_NOVERLAP: Final[int] = 128
+
+# EEG frequency bands (Hz)
+MU_BAND_LOW: Final[float] = 8.0
+MU_BAND_HIGH: Final[float] = 12.0
+BETA_BAND_LOW: Final[float] = 12.0
+BETA_BAND_HIGH: Final[float] = 30.0
+
+# =============================================================================
+# Test data dimensions
+# =============================================================================
+TEST_N_CHANNELS: Final[int] = 64
+TEST_N_TIMES: Final[int] = 480
+
+# =============================================================================
+# Machine Learning defaults
+# =============================================================================
+DEFAULT_N_COMPONENTS_PCA: Final[int] = 10
+DEFAULT_N_COMPONENTS_PCA_PIPELINE: Final[int] = 50
+
+# =============================================================================
+# Performance targets
+# =============================================================================
 TARGET_ACCURACY: Final[float] = 0.60
 
 # Prediction time limit (seconds)
 MAX_PREDICTION_TIME: Final[float] = 2.0
+
+# =============================================================================
+# Visualization constants
+# =============================================================================
+# DPI for saved plots
+PLOT_DPI: Final[int] = 300
+
+# Text separator widths
+SEPARATOR_WIDTH_WIDE: Final[int] = 70
+SEPARATOR_WIDTH_NORMAL: Final[int] = 50
+
+# Font sizes
+PLOT_FONTSIZE_LABEL: Final[int] = 12
+PLOT_FONTSIZE_TITLE: Final[int] = 14
+PLOT_FONTSIZE_LEGEND: Final[int] = 10
+
+# X-axis tick rotation (degrees)
+PLOT_XTICK_ROTATION: Final[int] = 45
+
+# Figure sizes (width, height in inches)
+PLOT_FIGSIZE_CV: Final[Tuple[int, int]] = (10, 6)
+PLOT_FIGSIZE_COMPARISON: Final[Tuple[int, int]] = (12, 6)
+PLOT_FIGSIZE_CONFUSION: Final[Tuple[int, int]] = (8, 6)
+PLOT_FIGSIZE_DETAILED: Final[Tuple[int, int]] = (14, 7)

--- a/src/features.py
+++ b/src/features.py
@@ -13,7 +13,18 @@ from numpy.typing import NDArray
 from scipy import signal
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from constants import EPSILON
+from constants import (
+    EPSILON,
+    EEG_SAMPLING_RATE,
+    WELCH_NPERSEG,
+    WELCH_NOVERLAP,
+    MU_BAND_LOW,
+    MU_BAND_HIGH,
+    BETA_BAND_LOW,
+    BETA_BAND_HIGH,
+    TEST_N_CHANNELS,
+    TEST_N_TIMES,
+)
 
 
 class PSDExtractor(BaseEstimator, TransformerMixin):
@@ -32,15 +43,15 @@ class PSDExtractor(BaseEstimator, TransformerMixin):
         Dictionary mapping band names to (low, high) frequency tuples
     """
 
-    def __init__(self, fs: float = 160.0, nperseg: int = 256,
-                 noverlap: int = 128,
+    def __init__(self, fs: float = EEG_SAMPLING_RATE, nperseg: int = WELCH_NPERSEG,
+                 noverlap: int = WELCH_NOVERLAP,
                  freq_bands: Optional[Dict[str, Tuple[float, float]]] = None) -> None:
         self.fs = fs
         self.nperseg = nperseg
         self.noverlap = noverlap
         self.freq_bands = freq_bands or {
-            'mu': (8, 12),
-            'beta': (12, 30),
+            'mu': (MU_BAND_LOW, MU_BAND_HIGH),
+            'beta': (BETA_BAND_LOW, BETA_BAND_HIGH),
         }
 
     def fit(self, X: NDArray[np.float64],
@@ -97,12 +108,12 @@ class BandPowerExtractor(BaseEstimator, TransformerMixin):
         Dictionary mapping band names to (low, high) frequency tuples
     """
 
-    def __init__(self, fs: float = 160.0,
+    def __init__(self, fs: float = EEG_SAMPLING_RATE,
                  freq_bands: Optional[Dict[str, Tuple[float, float]]] = None) -> None:
         self.fs = fs
         self.freq_bands = freq_bands or {
-            'mu': (8, 12),
-            'beta': (12, 30),
+            'mu': (MU_BAND_LOW, MU_BAND_HIGH),
+            'beta': (BETA_BAND_LOW, BETA_BAND_HIGH),
         }
 
     def fit(self, X: NDArray[np.float64],
@@ -238,16 +249,16 @@ if __name__ == "__main__":
     print("Testing feature extractors...")
 
     # Create dummy EEG data
-    n_epochs, n_channels, n_times = 10, 64, 480
+    n_epochs, n_channels, n_times = 10, TEST_N_CHANNELS, TEST_N_TIMES
     X = np.random.randn(n_epochs, n_channels, n_times)
 
     # Test PSD extractor
-    psd = PSDExtractor(fs=160.0)
+    psd = PSDExtractor(fs=EEG_SAMPLING_RATE)
     X_psd = psd.fit_transform(X)
     print(f"PSD features shape: {X_psd.shape}")
 
     # Test band power extractor
-    bp = BandPowerExtractor(fs=160.0)
+    bp = BandPowerExtractor(fs=EEG_SAMPLING_RATE)
     X_bp = bp.fit_transform(X)
     print(f"Band power features shape: {X_bp.shape}")
 

--- a/src/mycsp.py
+++ b/src/mycsp.py
@@ -18,15 +18,16 @@ __all__ = ['MyCSP', 'MyPCA']
 
 if __name__ == "__main__":
     import numpy as np
+    from constants import RANDOM_STATE, TEST_N_CHANNELS, TEST_N_TIMES, DEFAULT_N_COMPONENTS_PCA
 
     # Test CSP implementation
     print("Testing CSP implementation...")
 
     # Create dummy EEG data with 2 classes
-    np.random.seed(42)
+    np.random.seed(RANDOM_STATE)
     n_epochs = 100
-    n_channels = 64
-    n_times = 480
+    n_channels = TEST_N_CHANNELS
+    n_times = TEST_N_TIMES
 
     # Simulate class 1 with higher variance in first channels
     X1 = np.random.randn(n_epochs // 2, n_channels, n_times)
@@ -55,7 +56,7 @@ if __name__ == "__main__":
 
     # Test PCA
     X_flat = X.reshape(X.shape[0], -1)
-    pca = MyPCA(n_components=10)
+    pca = MyPCA(n_components=DEFAULT_N_COMPONENTS_PCA)
     X_pca = pca.fit_transform(X_flat)
 
     print(f"\nPCA input shape: {X_flat.shape}")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -14,6 +14,7 @@ from sklearn.svm import SVC
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import StandardScaler
 
+from constants import EEG_SAMPLING_RATE, DEFAULT_N_COMPONENTS_PCA_PIPELINE
 from mycsp import MyCSP, MyPCA
 from features import PSDExtractor, BandPowerExtractor, FlattenExtractor
 
@@ -99,7 +100,7 @@ def build_csp_lr_pipeline(n_components: int = 6, reg: Optional[float] = None,
     return pipeline
 
 
-def build_psd_lda_pipeline(fs: float = 160.0) -> Pipeline:
+def build_psd_lda_pipeline(fs: float = EEG_SAMPLING_RATE) -> Pipeline:
     """
     Build a PSD + LDA pipeline.
 
@@ -122,7 +123,7 @@ def build_psd_lda_pipeline(fs: float = 160.0) -> Pipeline:
     return pipeline
 
 
-def build_bandpower_lda_pipeline(fs: float = 160.0) -> Pipeline:
+def build_bandpower_lda_pipeline(fs: float = EEG_SAMPLING_RATE) -> Pipeline:
     """
     Build a Band Power + LDA pipeline.
 
@@ -143,7 +144,7 @@ def build_bandpower_lda_pipeline(fs: float = 160.0) -> Pipeline:
     return pipeline
 
 
-def build_flat_pca_lda_pipeline(n_components: int = 50) -> Pipeline:
+def build_flat_pca_lda_pipeline(n_components: int = DEFAULT_N_COMPONENTS_PCA_PIPELINE) -> Pipeline:
     """
     Build a Flatten + PCA + LDA pipeline.
 

--- a/src/training/core.py
+++ b/src/training/core.py
@@ -12,7 +12,7 @@ from sklearn.model_selection import cross_val_score, StratifiedKFold, train_test
 from sklearn.metrics import accuracy_score, classification_report, confusion_matrix
 from sklearn.pipeline import Pipeline
 
-from constants import RANDOM_STATE, TARGET_ACCURACY
+from constants import RANDOM_STATE, TARGET_ACCURACY, SEPARATOR_WIDTH_NORMAL
 from pipeline import get_pipeline
 from visualization import (plot_cv_scores, plot_confusion_matrix,
                            plot_training_summary)
@@ -65,7 +65,7 @@ def train_and_evaluate(X: NDArray[np.float64], y: NDArray[np.int64],
     scores = cross_val_score(pipeline, X, y, cv=cv_splitter, scoring='accuracy')
 
     if verbose:
-        sep = '=' * 50
+        sep = '=' * SEPARATOR_WIDTH_NORMAL
         print(f"\n{sep}")
         print(f"Pipeline: {pipeline_name}")
         print(f"{sep}")

--- a/src/transforms/pca.py
+++ b/src/transforms/pca.py
@@ -9,6 +9,8 @@ import numpy as np
 from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 
+from constants import DEFAULT_N_COMPONENTS_PCA
+
 
 class MyPCA(BaseEstimator, TransformerMixin):
     """
@@ -33,7 +35,7 @@ class MyPCA(BaseEstimator, TransformerMixin):
         Percentage of variance explained by each component
     """
 
-    def __init__(self, n_components: int = 10) -> None:
+    def __init__(self, n_components: int = DEFAULT_N_COMPONENTS_PCA) -> None:
         self.n_components = n_components
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'MyPCA':

--- a/src/visualization/_base.py
+++ b/src/visualization/_base.py
@@ -15,6 +15,8 @@ if os.environ.get('DISPLAY') is None:
 import matplotlib.pyplot as plt
 from typing import Optional
 
+from constants import PLOT_DPI
+
 
 def _finalize_plot(fig, save_path: Optional[str] = None, show: bool = False):
     """
@@ -39,7 +41,7 @@ def _finalize_plot(fig, save_path: Optional[str] = None, show: bool = False):
         save_dir = os.path.dirname(save_path)
         if save_dir:
             os.makedirs(save_dir, exist_ok=True)
-        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        plt.savefig(save_path, dpi=PLOT_DPI, bbox_inches='tight')
         print(f"  [Plot saved: {save_path}]")
 
     if show:

--- a/src/visualization/comparison_plots.py
+++ b/src/visualization/comparison_plots.py
@@ -8,7 +8,14 @@ import numpy as np
 import matplotlib.pyplot as plt
 from typing import Dict, Optional
 
-from constants import TARGET_ACCURACY
+from constants import (
+    TARGET_ACCURACY,
+    PLOT_FIGSIZE_COMPARISON,
+    PLOT_FONTSIZE_LABEL,
+    PLOT_FONTSIZE_TITLE,
+    PLOT_FONTSIZE_LEGEND,
+    PLOT_XTICK_ROTATION,
+)
 from visualization._base import _finalize_plot
 
 
@@ -53,7 +60,7 @@ def plot_pipeline_comparison(results: Dict[str, Dict],
     means = [item[1]['mean'] for item in sorted_results]
     stds = [item[1]['std'] for item in sorted_results]
 
-    fig, ax = plt.subplots(figsize=(12, 6))
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE_COMPARISON)
 
     # Bar plot with error bars
     x_pos = np.arange(len(names))
@@ -67,13 +74,13 @@ def plot_pipeline_comparison(results: Dict[str, Dict],
                label=f'Target: {TARGET_ACCURACY:.2f}')
 
     # Styling
-    ax.set_xlabel('Pipeline', fontsize=12)
-    ax.set_ylabel('Mean Accuracy', fontsize=12)
-    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xlabel('Pipeline', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_ylabel('Mean Accuracy', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_title(title, fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold')
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(names, rotation=45, ha='right')
+    ax.set_xticklabels(names, rotation=PLOT_XTICK_ROTATION, ha='right')
     ax.set_ylim([0, 1])
-    ax.legend(fontsize=10)
+    ax.legend(fontsize=PLOT_FONTSIZE_LEGEND)
     ax.grid(axis='y', alpha=0.3)
 
     # Add value labels on bars

--- a/src/visualization/cv_plots.py
+++ b/src/visualization/cv_plots.py
@@ -8,7 +8,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 from typing import Dict, Optional
 
-from constants import TARGET_ACCURACY
+from constants import (
+    TARGET_ACCURACY,
+    PLOT_FIGSIZE_CV,
+    PLOT_FIGSIZE_DETAILED,
+    PLOT_FONTSIZE_LABEL,
+    PLOT_FONTSIZE_TITLE,
+    PLOT_FONTSIZE_LEGEND,
+    PLOT_XTICK_ROTATION,
+)
 from visualization._base import _finalize_plot
 
 
@@ -35,7 +43,7 @@ def plot_cv_scores(scores: np.ndarray,
     fig : matplotlib.figure.Figure
         The generated figure
     """
-    fig, ax = plt.subplots(figsize=(10, 6))
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE_CV)
 
     # Bar plot for each fold
     folds = np.arange(1, len(scores) + 1)
@@ -51,12 +59,12 @@ def plot_cv_scores(scores: np.ndarray,
                label=f'Target: {TARGET_ACCURACY:.2f}')
 
     # Styling
-    ax.set_xlabel('Fold', fontsize=12)
-    ax.set_ylabel('Accuracy', fontsize=12)
-    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xlabel('Fold', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_ylabel('Accuracy', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_title(title, fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold')
     ax.set_ylim([0, 1])
     ax.set_xticks(folds)
-    ax.legend(fontsize=10)
+    ax.legend(fontsize=PLOT_FONTSIZE_LEGEND)
     ax.grid(axis='y', alpha=0.3)
 
     # Add value labels on bars
@@ -98,7 +106,7 @@ def plot_cv_detailed(results: Dict[str, Dict],
         print("No valid results to plot")
         return None
 
-    fig, ax = plt.subplots(figsize=(14, 7))
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE_DETAILED)
 
     # Create box plots
     data = [v['scores'] for v in valid_results.values()]
@@ -117,12 +125,12 @@ def plot_cv_detailed(results: Dict[str, Dict],
                label=f'Target: {TARGET_ACCURACY:.2f}')
 
     # Styling
-    ax.set_xlabel('Pipeline', fontsize=12)
-    ax.set_ylabel('Accuracy', fontsize=12)
-    ax.set_title(title, fontsize=14, fontweight='bold')
-    ax.set_xticklabels(names, rotation=45, ha='right')
+    ax.set_xlabel('Pipeline', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_ylabel('Accuracy', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_title(title, fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold')
+    ax.set_xticklabels(names, rotation=PLOT_XTICK_ROTATION, ha='right')
     ax.set_ylim([0, 1])
-    ax.legend(fontsize=10)
+    ax.legend(fontsize=PLOT_FONTSIZE_LEGEND)
     ax.grid(axis='y', alpha=0.3)
 
     plt.tight_layout()

--- a/src/visualization/metrics_plots.py
+++ b/src/visualization/metrics_plots.py
@@ -9,7 +9,12 @@ import matplotlib.pyplot as plt
 from sklearn.metrics import confusion_matrix
 from typing import List, Optional
 
-from constants import TARGET_ACCURACY
+from constants import (
+    TARGET_ACCURACY,
+    PLOT_FIGSIZE_CONFUSION,
+    PLOT_FONTSIZE_LABEL,
+    PLOT_FONTSIZE_TITLE,
+)
 from visualization._base import _finalize_plot
 
 
@@ -44,14 +49,14 @@ def plot_confusion_matrix(y_true: np.ndarray,
     """
     cm = confusion_matrix(y_true, y_pred)
 
-    fig, ax = plt.subplots(figsize=(8, 6))
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE_CONFUSION)
 
     # Use matplotlib imshow for heatmap
     im = ax.imshow(cm, cmap='Blues', aspect='auto')
 
     # Add colorbar
     cbar = plt.colorbar(im, ax=ax)
-    cbar.set_label('Count', fontsize=12)
+    cbar.set_label('Count', fontsize=PLOT_FONTSIZE_LABEL)
 
     # Set ticks and labels
     classes = class_names or np.unique(y_true)
@@ -67,11 +72,11 @@ def plot_confusion_matrix(y_true: np.ndarray,
             ax.text(
                 j, i, str(cm[i, j]),
                 ha="center", va="center", color=txt_color,
-                fontsize=14, fontweight='bold')
+                fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold')
 
-    ax.set_xlabel('Predicted Label', fontsize=12)
-    ax.set_ylabel('True Label', fontsize=12)
-    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xlabel('Predicted Label', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_ylabel('True Label', fontsize=PLOT_FONTSIZE_LABEL)
+    ax.set_title(title, fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold')
 
     plt.tight_layout()
     return _finalize_plot(fig, save_path, show)
@@ -122,11 +127,11 @@ def plot_training_summary(
         mean_score, color='red', linestyle='--', linewidth=2,
         label=f'Mean: {mean_score:.4f}')
     ax1.axhline(
-        0.60, color='green', linestyle='--', linewidth=2,
-        label='Target: 0.60')
+        TARGET_ACCURACY, color='green', linestyle='--', linewidth=2,
+        label=f'Target: {TARGET_ACCURACY:.2f}')
     ax1.set_xlabel('Fold', fontsize=10)
     ax1.set_ylabel('Accuracy', fontsize=10)
-    ax1.set_title('Cross-Validation Scores', fontsize=12, fontweight='bold')
+    ax1.set_title('Cross-Validation Scores', fontsize=PLOT_FONTSIZE_LABEL, fontweight='bold')
     ax1.set_ylim([0, 1])
     ax1.set_xticks(folds)
     ax1.legend(fontsize=8)
@@ -165,7 +170,7 @@ def plot_training_summary(
 
     ax2.set_xlabel('Predicted Label', fontsize=10)
     ax2.set_ylabel('True Label', fontsize=10)
-    ax2.set_title('Confusion Matrix', fontsize=12, fontweight='bold')
+    ax2.set_title('Confusion Matrix', fontsize=PLOT_FONTSIZE_LABEL, fontweight='bold')
 
     # Subplot 3: Accuracy per class
     ax3 = plt.subplot(1, 3, 3)
@@ -183,7 +188,7 @@ def plot_training_summary(
         label=f'Target: {TARGET_ACCURACY:.2f}')
     ax3.set_xlabel('Class', fontsize=10)
     ax3.set_ylabel('Accuracy', fontsize=10)
-    ax3.set_title('Per-Class Accuracy', fontsize=12, fontweight='bold')
+    ax3.set_title('Per-Class Accuracy', fontsize=PLOT_FONTSIZE_LABEL, fontweight='bold')
     ax3.set_ylim([0, 1])
     ax3.set_xticks(classes)
     if class_names:
@@ -198,6 +203,6 @@ def plot_training_summary(
 
     plt.suptitle(
         f'Training Summary: {pipeline_name}',
-        fontsize=14, fontweight='bold', y=1.02)
+        fontsize=PLOT_FONTSIZE_TITLE, fontweight='bold', y=1.02)
     plt.tight_layout()
     return _finalize_plot(fig, save_path, show)


### PR DESCRIPTION
- Extend src/constants.py with 30+ new constants organized by category:
  * EEG Signal Processing: EEG_SAMPLING_RATE, WELCH_NPERSEG, WELCH_NOVERLAP, MU_BAND_LOW/HIGH, BETA_BAND_LOW/HIGH, EEG_BANDPASS_LOW/HIGH
  * Test data dimensions: TEST_N_CHANNELS, TEST_N_TIMES
  * ML defaults: DEFAULT_N_COMPONENTS_PCA, DEFAULT_N_COMPONENTS_PCA_PIPELINE
  * Visualization: PLOT_DPI, SEPARATOR_WIDTH_WIDE/NORMAL, PLOT_FONTSIZE_*, PLOT_XTICK_ROTATION, PLOT_FIGSIZE_* tuples
  * Dataset defaults: DEFAULT_SUBJECT, DEFAULT_RUN

- Refactor 11 files to use named constants:
  * demo_plots.py: Use DEFAULT_SUBJECT, DEFAULT_RUN, SEPARATOR_WIDTH_WIDE
  * src/features.py: Use EEG signal constants for PSD/bandpower extraction
  * src/mycsp.py: Use RANDOM_STATE, TEST_N_* constants in test code
  * src/pipeline.py: Use EEG_SAMPLING_RATE, DEFAULT_N_COMPONENTS_PCA_PIPELINE
  * src/training/core.py: Use SEPARATOR_WIDTH_NORMAL
  * src/transforms/pca.py: Use DEFAULT_N_COMPONENTS_PCA
  * src/visualization/*.py: Use PLOT_DPI, PLOT_FIGSIZE_*, PLOT_FONTSIZE_*

This improves code maintainability and makes configuration changes easier.