### PR TITLE
Add wavelet transform, custom classifier, and custom linear algebra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ description = "EEG Brain-Computer Interface for motor imagery classification"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "numpy>=2.4.2",
+    "pytest>=9.0.2",
     "requests>=2.32.5",
+    "scikit-learn>=1.8.0",
+    "scipy>=1.17.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/classifiers/__init__.py
+++ b/src/classifiers/__init__.py
@@ -1,0 +1,10 @@
+"""
+Custom classifiers package for EEG classification.
+
+Classes:
+    MyNearestCentroid: Minimum distance classifier using class centroids
+"""
+
+from classifiers.nearest_centroid import MyNearestCentroid
+
+__all__ = ['MyNearestCentroid']

--- a/src/classifiers/nearest_centroid.py
+++ b/src/classifiers/nearest_centroid.py
@@ -1,0 +1,163 @@
+"""
+Custom Nearest Centroid classifier implementation.
+
+A simple but effective classifier for EEG-based BCI that classifies
+samples based on their Euclidean distance to class centroids.
+Supports optional shrinkage regularization for high-dimensional data.
+"""
+
+from typing import Optional
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.base import BaseEstimator, ClassifierMixin
+
+
+class MyNearestCentroid(BaseEstimator, ClassifierMixin):
+    """
+    Custom Nearest Centroid classifier as sklearn-compatible estimator.
+
+    Computes the centroid (mean) of each class during fitting, then
+    classifies new samples by assigning them to the class whose
+    centroid is closest (Euclidean distance).
+
+    Optionally applies shrinkage regularization which moves class
+    centroids toward the overall centroid, helping with
+    high-dimensional or noisy features.
+
+    Parameters
+    ----------
+    shrink_threshold : float or None
+        Shrinkage threshold for regularization. If not None, each
+        feature's deviation from the overall centroid is shrunk
+        toward zero. Higher values produce more regularization.
+        Default: None (no shrinkage)
+
+    Attributes
+    ----------
+    classes_ : np.ndarray
+        Unique class labels found during fit
+    centroids_ : np.ndarray
+        Class centroids of shape (n_classes, n_features)
+    overall_centroid_ : np.ndarray
+        Overall centroid of shape (n_features,)
+    """
+
+    def __init__(self, shrink_threshold: Optional[float] = None) -> None:
+        self.shrink_threshold = shrink_threshold
+
+    def fit(self, X: NDArray[np.float64],
+            y: NDArray[np.int64]) -> 'MyNearestCentroid':
+        """
+        Fit the classifier by computing class centroids.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Training data of shape (n_samples, n_features)
+        y : np.ndarray
+            Target labels of shape (n_samples,)
+
+        Returns
+        -------
+        self : MyNearestCentroid
+            The fitted classifier
+        """
+        self.classes_ = np.unique(y)
+        n_classes = len(self.classes_)
+        n_features = X.shape[1]
+
+        # Compute overall centroid
+        self.overall_centroid_ = np.mean(X, axis=0)
+
+        # Compute per-class centroids from scratch
+        self.centroids_ = np.zeros((n_classes, n_features),
+                                   dtype=np.float64)
+        for i, cls in enumerate(self.classes_):
+            mask = (y == cls)
+            n_samples_cls = np.sum(mask)
+            # Manual mean computation
+            centroid = np.zeros(n_features, dtype=np.float64)
+            for j in range(X.shape[0]):
+                if mask[j]:
+                    for k in range(n_features):
+                        centroid[k] += X[j, k]
+            centroid /= n_samples_cls
+            self.centroids_[i] = centroid
+
+        # Apply shrinkage regularization if threshold is set
+        if self.shrink_threshold is not None:
+            for i in range(n_classes):
+                deviation = self.centroids_[i] - self.overall_centroid_
+                # Soft-threshold each feature's deviation
+                sign = np.sign(deviation)
+                magnitude = np.abs(deviation)
+                shrunk = np.maximum(
+                    magnitude - self.shrink_threshold, 0.0)
+                self.centroids_[i] = (
+                    self.overall_centroid_ + sign * shrunk)
+
+        return self
+
+    def predict(self, X: NDArray[np.float64]) -> NDArray[np.int64]:
+        """
+        Predict class labels for samples in X.
+
+        Assigns each sample to the class whose centroid is nearest
+        (minimum Euclidean distance).
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Test data of shape (n_samples, n_features)
+
+        Returns
+        -------
+        predictions : np.ndarray
+            Predicted class labels of shape (n_samples,)
+        """
+        if not hasattr(self, 'centroids_'):
+            raise RuntimeError(
+                "Classifier not fitted. Call fit() first.")
+
+        n_samples = X.shape[0]
+        predictions = np.zeros(n_samples, dtype=self.classes_.dtype)
+
+        for i in range(n_samples):
+            # Compute Euclidean distance to each centroid
+            min_dist = np.inf
+            best_class = self.classes_[0]
+            for j, cls in enumerate(self.classes_):
+                # Manual distance computation
+                dist = 0.0
+                for k in range(X.shape[1]):
+                    diff = X[i, k] - self.centroids_[j, k]
+                    dist += diff * diff
+                dist = np.sqrt(dist)
+
+                if dist < min_dist:
+                    min_dist = dist
+                    best_class = cls
+
+            predictions[i] = best_class
+
+        return predictions
+
+    def score(self, X: NDArray[np.float64],
+              y: NDArray[np.int64]) -> float:
+        """
+        Compute accuracy score for the given test data and labels.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Test data of shape (n_samples, n_features)
+        y : np.ndarray
+            True labels of shape (n_samples,)
+
+        Returns
+        -------
+        accuracy : float
+            Fraction of correctly classified samples
+        """
+        predictions = self.predict(X)
+        return float(np.mean(predictions == y))

--- a/src/features.py
+++ b/src/features.py
@@ -5,6 +5,7 @@ Implements various feature extraction methods:
 - Power Spectral Density (PSD) using Welch method
 - Band power extraction
 - Log variance features
+- Wavelet transform (custom Morlet CWT implementation)
 """
 
 from typing import Dict, Tuple, Optional
@@ -245,6 +246,208 @@ class FlattenExtractor(BaseEstimator, TransformerMixin):
         """
         n_epochs = X.shape[0]
         return X.reshape(n_epochs, -1)
+
+
+def _morlet_wavelet(n_points: int, scale: float, fs: float,
+                    omega0: float = 5.0) -> NDArray[np.float64]:
+    """
+    Generate a Morlet wavelet at a given scale.
+
+    The Morlet wavelet is defined as:
+        psi(t) = pi^{-1/4} * exp(i * omega0 * t) * exp(-t^2 / 2)
+
+    Parameters
+    ----------
+    n_points : int
+        Number of time points for the wavelet
+    scale : float
+        Scale parameter (controls frequency resolution)
+    fs : float
+        Sampling frequency
+    omega0 : float
+        Central frequency of the wavelet (default: 5.0)
+
+    Returns
+    -------
+    wavelet : np.ndarray
+        Complex Morlet wavelet of shape (n_points,)
+    """
+    # Sample indices centered at 0
+    n = np.arange(n_points) - n_points // 2
+    # Normalized time: scale is in sample units (from _freq_to_scale)
+    eta = n / scale
+    # Morlet wavelet with normalization
+    norm = (np.pi ** (-0.25)) / np.sqrt(scale)
+    wavelet = norm * np.exp(1j * omega0 * eta) * np.exp(-eta ** 2 / 2.0)
+    return wavelet
+
+
+def _cwt_morlet(x: NDArray[np.float64], scales: NDArray[np.float64],
+                fs: float, omega0: float = 5.0) -> NDArray[np.float64]:
+    """
+    Compute the Continuous Wavelet Transform using Morlet wavelets.
+
+    Implements CWT via convolution in the frequency domain (FFT-based)
+    for efficiency.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input signal of shape (n_times,)
+    scales : np.ndarray
+        Array of wavelet scales
+    fs : float
+        Sampling frequency
+    omega0 : float
+        Morlet wavelet central frequency
+
+    Returns
+    -------
+    coefficients : np.ndarray
+        CWT coefficients of shape (n_scales, n_times)
+    """
+    n_times = len(x)
+    n_scales = len(scales)
+
+    # FFT of the input signal
+    x_fft = np.fft.fft(x)
+
+    coefficients = np.zeros((n_scales, n_times), dtype=np.float64)
+
+    for i, scale in enumerate(scales):
+        # Generate wavelet in time domain, then FFT
+        wavelet = _morlet_wavelet(n_times, scale, fs, omega0)
+        wavelet_fft = np.fft.fft(wavelet)
+
+        # Convolution via FFT multiplication
+        conv = np.fft.ifft(x_fft * np.conj(wavelet_fft))
+        coefficients[i, :] = np.abs(conv)
+
+    return coefficients
+
+
+def _freq_to_scale(freq: float, fs: float,
+                   omega0: float = 5.0) -> float:
+    """
+    Convert a frequency to the corresponding Morlet wavelet scale.
+
+    For the Morlet wavelet, the relationship between scale and
+    pseudo-frequency is: f = omega0 / (2 * pi * scale)
+
+    Parameters
+    ----------
+    freq : float
+        Target frequency in Hz
+    fs : float
+        Sampling frequency
+    omega0 : float
+        Morlet wavelet central frequency
+
+    Returns
+    -------
+    scale : float
+        Corresponding wavelet scale
+    """
+    return float(omega0 / (2.0 * np.pi * freq) * fs)
+
+
+class WaveletExtractor(BaseEstimator, TransformerMixin):
+    """
+    Extract wavelet transform features from EEG data.
+
+    Uses a custom Continuous Wavelet Transform (CWT) implementation
+    with Morlet wavelets to compute time-frequency energy features
+    in physiologically relevant EEG frequency bands (mu and beta).
+
+    Parameters
+    ----------
+    fs : float
+        Sampling frequency of the EEG signal
+    freq_bands : dict or None
+        Dictionary mapping band names to (low, high) frequency tuples.
+        Default: mu (8-12 Hz) and beta (12-30 Hz) bands.
+    n_scales_per_band : int
+        Number of wavelet scales to sample within each frequency band
+    omega0 : float
+        Morlet wavelet central frequency parameter
+    """
+
+    def __init__(self, fs: float = EEG_SAMPLING_RATE,
+                 freq_bands: Optional[Dict[str, Tuple[float, float]]] = None,
+                 n_scales_per_band: int = 5,
+                 omega0: float = 5.0) -> None:
+        self.fs = fs
+        self.freq_bands = freq_bands or {
+            'mu': (MU_BAND_LOW, MU_BAND_HIGH),
+            'beta': (BETA_BAND_LOW, BETA_BAND_HIGH),
+        }
+        self.n_scales_per_band = n_scales_per_band
+        self.omega0 = omega0
+
+    def fit(self, X: NDArray[np.float64],
+            y: Optional[NDArray[np.int64]] = None) -> 'WaveletExtractor':
+        """Fit method (nothing to fit for wavelet extraction)."""
+        return self
+
+    def transform(self, X: NDArray[np.float64]) -> NDArray[np.float64]:
+        """
+        Extract wavelet energy features from EEG epochs.
+
+        For each epoch and channel, computes the CWT using Morlet wavelets
+        at scales corresponding to the target frequency bands. Returns the
+        mean energy (squared magnitude) of the CWT coefficients within each
+        band.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            EEG data of shape (n_epochs, n_channels, n_times)
+
+        Returns
+        -------
+        features : np.ndarray
+            Wavelet features of shape (n_epochs, n_channels * n_bands)
+        """
+        n_epochs, n_channels, n_times = X.shape
+        n_bands = len(self.freq_bands)
+        features = np.zeros((n_epochs, n_channels * n_bands))
+
+        # Pre-compute scales for each band
+        band_scales = {}
+        for band_name, (low, high) in self.freq_bands.items():
+            freqs = np.linspace(low, high, self.n_scales_per_band)
+            scales = np.array([
+                _freq_to_scale(f, self.fs, self.omega0)
+                for f in freqs
+            ])
+            band_scales[band_name] = scales
+
+        # Concatenate all scales for a single CWT pass
+        all_scales = np.concatenate(list(band_scales.values()))
+        band_boundaries = []
+        start = 0
+        for band_name in self.freq_bands:
+            n_sc = len(band_scales[band_name])
+            band_boundaries.append((start, start + n_sc))
+            start += n_sc
+
+        for epoch_idx in range(n_epochs):
+            for ch_idx in range(n_channels):
+                sig = X[epoch_idx, ch_idx, :]
+
+                # Compute CWT for all scales at once
+                cwt_coeffs = _cwt_morlet(
+                    sig, all_scales, self.fs, self.omega0)
+
+                # Extract mean energy per band
+                for band_idx, (s_start, s_end) in enumerate(
+                        band_boundaries):
+                    band_energy = np.mean(
+                        cwt_coeffs[s_start:s_end, :] ** 2)
+                    feat_idx = ch_idx * n_bands + band_idx
+                    features[epoch_idx, feat_idx] = band_energy
+
+        return features
 
 
 if __name__ == "__main__":

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -18,7 +18,9 @@ from sklearn.preprocessing import StandardScaler
 from constants import (EEG_SAMPLING_RATE, DEFAULT_N_COMPONENTS_PCA_PIPELINE,
                        RANDOM_STATE)
 from transforms import MyCSP, MyPCA
-from features import PSDExtractor, BandPowerExtractor, FlattenExtractor
+from features import (PSDExtractor, BandPowerExtractor, FlattenExtractor,
+                      WaveletExtractor)
+from classifiers import MyNearestCentroid
 
 
 def build_csp_lda_pipeline(n_components: int = 6, reg: Optional[float] = None) -> Pipeline:
@@ -197,6 +199,99 @@ def build_flat_pca_lda_pipeline(n_components: int = DEFAULT_N_COMPONENTS_PCA_PIP
     return pipeline
 
 
+def build_wavelet_lda_pipeline(
+        fs: float = EEG_SAMPLING_RATE,
+        n_scales_per_band: int = 5) -> Pipeline:
+    """
+    Build a Wavelet + LDA pipeline.
+
+    Uses Continuous Wavelet Transform (Morlet) to extract time-frequency
+    energy features, followed by LDA classification.
+
+    Parameters
+    ----------
+    fs : float
+        Sampling frequency
+    n_scales_per_band : int
+        Number of wavelet scales per frequency band
+
+    Returns
+    -------
+    pipeline : Pipeline
+    """
+    pipeline = Pipeline([
+        ('wavelet', WaveletExtractor(
+            fs=fs, n_scales_per_band=n_scales_per_band)),
+        ('scaler', StandardScaler()),
+        ('lda', LinearDiscriminantAnalysis())
+    ])
+    return pipeline
+
+
+def build_wavelet_custom_pipeline(
+        fs: float = EEG_SAMPLING_RATE,
+        n_scales_per_band: int = 5,
+        shrink_threshold: Optional[float] = None) -> Pipeline:
+    """
+    Build a Wavelet + custom Nearest Centroid pipeline.
+
+    Uses Continuous Wavelet Transform features with a custom
+    nearest centroid classifier.
+
+    Parameters
+    ----------
+    fs : float
+        Sampling frequency
+    n_scales_per_band : int
+        Number of wavelet scales per frequency band
+    shrink_threshold : float or None
+        Shrinkage threshold for the classifier
+
+    Returns
+    -------
+    pipeline : Pipeline
+    """
+    pipeline = Pipeline([
+        ('wavelet', WaveletExtractor(
+            fs=fs, n_scales_per_band=n_scales_per_band)),
+        ('scaler', StandardScaler()),
+        ('clf', MyNearestCentroid(
+            shrink_threshold=shrink_threshold))
+    ])
+    return pipeline
+
+
+def build_csp_custom_pipeline(
+        n_components: int = 6,
+        reg: Optional[float] = None,
+        shrink_threshold: Optional[float] = None) -> Pipeline:
+    """
+    Build a CSP + custom Nearest Centroid pipeline.
+
+    Uses CSP spatial filtering with a custom nearest centroid classifier.
+
+    Parameters
+    ----------
+    n_components : int
+        Number of CSP components
+    reg : float
+        Regularization for CSP
+    shrink_threshold : float or None
+        Shrinkage threshold for the classifier
+
+    Returns
+    -------
+    pipeline : Pipeline
+    """
+    pipeline = Pipeline([
+        ('csp', MyCSP(n_components=n_components, reg=reg, log=True)),
+        ('scaler', StandardScaler()),
+        ('clf', MyNearestCentroid(
+            shrink_threshold=shrink_threshold))
+    ])
+    return pipeline
+
+
 def get_pipeline(pipeline_name: str = 'csp_lda', **kwargs) -> Pipeline:
     """
     Get a pipeline by name.
@@ -212,6 +307,9 @@ def get_pipeline(pipeline_name: str = 'csp_lda', **kwargs) -> Pipeline:
         - 'psd_lda': PSD features + LDA
         - 'bandpower_lda': Band power features + LDA
         - 'flat_pca_lda': Flattened + PCA + LDA
+        - 'wavelet_lda': Wavelet transform + LDA
+        - 'wavelet_custom': Wavelet + custom Nearest Centroid
+        - 'csp_custom': CSP + custom Nearest Centroid
     **kwargs : dict
         Additional arguments for the pipeline constructor
 
@@ -227,6 +325,9 @@ def get_pipeline(pipeline_name: str = 'csp_lda', **kwargs) -> Pipeline:
         'psd_lda': build_psd_lda_pipeline,
         'bandpower_lda': build_bandpower_lda_pipeline,
         'flat_pca_lda': build_flat_pca_lda_pipeline,
+        'wavelet_lda': build_wavelet_lda_pipeline,
+        'wavelet_custom': build_wavelet_custom_pipeline,
+        'csp_custom': build_csp_custom_pipeline,
     }
 
     if pipeline_name not in pipelines:
@@ -242,6 +343,7 @@ def list_pipelines() -> list:
     return [
         'csp_lda', 'csp_svm', 'csp_lr', 'csp_rf',
         'psd_lda', 'bandpower_lda', 'flat_pca_lda',
+        'wavelet_lda', 'wavelet_custom', 'csp_custom',
     ]
 
 

--- a/src/transforms/__init__.py
+++ b/src/transforms/__init__.py
@@ -1,12 +1,15 @@
 """
 Transforms package for EEG signal processing.
 
-This package provides spatial filtering and dimensionality reduction
-techniques for EEG-based Brain-Computer Interfaces.
+This package provides spatial filtering, dimensionality reduction,
+and custom linear algebra techniques for EEG-based Brain-Computer Interfaces.
 
 Classes:
     MyCSP: Common Spatial Patterns implementation
     MyPCA: Principal Component Analysis implementation
+
+Modules:
+    linalg: Custom linear algebra (eigenvalue, covariance, SVD, Cholesky)
 """
 
 from transforms.csp import MyCSP

--- a/src/transforms/csp.py
+++ b/src/transforms/csp.py
@@ -24,10 +24,10 @@ are the most discriminative spatial filters.
 
 from typing import Optional
 import numpy as np
-from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from constants import EPSILON, EPSILON_SMALL
+from transforms.linalg import my_eigh_generalized
 
 
 class MyCSP(BaseEstimator, TransformerMixin):
@@ -126,15 +126,10 @@ class MyCSP(BaseEstimator, TransformerMixin):
         cov_composite = cov1 + cov2
 
         # Solve generalized eigenvalue problem: cov1 @ W = cov_composite @ W @ D
-        # This is equivalent to finding eigenvectors of cov_composite^(-1) @ cov1
-        try:
-            eigenvalues, eigenvectors = linalg.eigh(cov1, cov_composite)
-        except linalg.LinAlgError:
-            # If decomposition fails, add regularization
-            eigenvalues, eigenvectors = linalg.eigh(
-                cov1 + EPSILON_SMALL * np.eye(cov1.shape[0]),
-                cov_composite + EPSILON_SMALL * np.eye(cov_composite.shape[0])
-            )
+        # Uses custom Jacobi-based solver with Cholesky reduction
+        eigenvalues, eigenvectors = my_eigh_generalized(
+            cov1, cov_composite
+        )
 
         # Sort eigenvalues and eigenvectors in descending order
         sorted_idx = np.argsort(eigenvalues)[::-1]

--- a/src/transforms/linalg.py
+++ b/src/transforms/linalg.py
@@ -1,0 +1,410 @@
+"""
+Custom linear algebra implementations.
+
+Provides hand-coded replacements for scipy/numpy linear algebra functions:
+- Covariance matrix computation
+- Cholesky decomposition
+- Jacobi eigenvalue algorithm for symmetric matrices
+- Generalized eigenvalue problem solver
+- SVD via eigendecomposition
+
+These implementations avoid relying on scipy.linalg for core decompositions,
+demonstrating the underlying mathematical algorithms.
+"""
+
+from typing import Tuple
+import numpy as np
+from numpy.typing import NDArray
+
+from constants import EPSILON, EPSILON_SMALL
+
+
+def my_covariance(X: NDArray[np.float64],
+                  rowvar: bool = True) -> NDArray[np.float64]:
+    """
+    Compute the covariance matrix from scratch.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Data matrix. If rowvar=True, each row is a variable and columns are
+        observations. If rowvar=False, each column is a variable.
+    rowvar : bool
+        If True, rows are variables (default). If False, columns are variables.
+
+    Returns
+    -------
+    cov : np.ndarray
+        Covariance matrix of shape (n_vars, n_vars)
+    """
+    if not rowvar:
+        X = X.T
+
+    n_vars, n_obs = X.shape
+
+    # Center the data (subtract mean of each variable)
+    mean = np.zeros(n_vars)
+    for i in range(n_vars):
+        s = 0.0
+        for j in range(n_obs):
+            s += X[i, j]
+        mean[i] = s / n_obs
+
+    X_centered = np.empty_like(X)
+    for i in range(n_vars):
+        for j in range(n_obs):
+            X_centered[i, j] = X[i, j] - mean[i]
+
+    # Compute covariance: cov = X_centered @ X_centered.T / (n_obs - 1)
+    cov = np.zeros((n_vars, n_vars))
+    for i in range(n_vars):
+        for j in range(i, n_vars):
+            s = 0.0
+            for k in range(n_obs):
+                s += X_centered[i, k] * X_centered[j, k]
+            cov[i, j] = s / (n_obs - 1)
+            cov[j, i] = cov[i, j]  # Symmetric
+
+    return cov
+
+
+def my_cholesky(A: NDArray[np.float64]) -> NDArray[np.float64]:
+    """
+    Compute the Cholesky decomposition A = L @ L.T.
+
+    Uses the Cholesky-Banachiewicz algorithm with vectorized
+    dot products for the inner sums.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Symmetric positive-definite matrix of shape (n, n)
+
+    Returns
+    -------
+    L : np.ndarray
+        Lower triangular matrix of shape (n, n)
+
+    Raises
+    ------
+    ValueError
+        If the matrix is not positive definite
+    """
+    n = A.shape[0]
+    L = np.zeros((n, n), dtype=np.float64)
+
+    for i in range(n):
+        # Vectorized dot product for off-diagonal elements
+        for j in range(i):
+            s = np.dot(L[i, :j], L[j, :j])
+            L[i, j] = (A[i, j] - s) / L[j, j]
+
+        # Diagonal element
+        s = np.dot(L[i, :i], L[i, :i])
+        val = A[i, i] - s
+        if val <= 0:
+            raise ValueError(
+                "Matrix is not positive definite "
+                f"(diagonal element {i} = {val})")
+        L[i, i] = np.sqrt(val)
+
+    return L
+
+
+def _solve_lower_triangular(
+    L: NDArray[np.float64],
+    b: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """
+    Solve L @ x = b where L is lower triangular (forward substitution).
+
+    Parameters
+    ----------
+    L : np.ndarray
+        Lower triangular matrix of shape (n, n)
+    b : np.ndarray
+        Right-hand side vector of shape (n,)
+
+    Returns
+    -------
+    x : np.ndarray
+        Solution vector of shape (n,)
+    """
+    n = L.shape[0]
+    x = np.zeros(n, dtype=np.float64)
+
+    for i in range(n):
+        s = np.dot(L[i, :i], x[:i])
+        x[i] = (b[i] - s) / L[i, i]
+
+    return x
+
+
+def _solve_upper_triangular(
+    U: NDArray[np.float64],
+    b: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """
+    Solve U @ x = b where U is upper triangular (back substitution).
+
+    Parameters
+    ----------
+    U : np.ndarray
+        Upper triangular matrix of shape (n, n)
+    b : np.ndarray
+        Right-hand side vector of shape (n,)
+
+    Returns
+    -------
+    x : np.ndarray
+        Solution vector of shape (n,)
+    """
+    n = U.shape[0]
+    x = np.zeros(n, dtype=np.float64)
+
+    for i in range(n - 1, -1, -1):
+        s = np.dot(U[i, i + 1:], x[i + 1:])
+        x[i] = (b[i] - s) / U[i, i]
+
+    return x
+
+
+def _invert_lower_triangular(L: NDArray[np.float64]) -> NDArray[np.float64]:
+    """
+    Compute the inverse of a lower triangular matrix.
+
+    Parameters
+    ----------
+    L : np.ndarray
+        Lower triangular matrix of shape (n, n)
+
+    Returns
+    -------
+    L_inv : np.ndarray
+        Inverse of L, also lower triangular
+    """
+    n = L.shape[0]
+    L_inv = np.zeros((n, n), dtype=np.float64)
+
+    for j in range(n):
+        e_j = np.zeros(n)
+        e_j[j] = 1.0
+        L_inv[:, j] = _solve_lower_triangular(L, e_j)
+
+    return L_inv
+
+
+def my_eigh(A: NDArray[np.float64],
+            max_iter: int = 200) -> Tuple[NDArray[np.float64],
+                                          NDArray[np.float64]]:
+    """
+    Compute eigenvalues and eigenvectors of a symmetric matrix
+    using the Jacobi eigenvalue algorithm.
+
+    The Jacobi method iteratively applies Givens rotations to
+    diagonalize the matrix. Each rotation zeros out an off-diagonal
+    element. Uses vectorized numpy operations for performance.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Symmetric matrix of shape (n, n)
+    max_iter : int
+        Maximum number of sweep iterations (default: 200)
+
+    Returns
+    -------
+    eigenvalues : np.ndarray
+        Eigenvalues in ascending order (n,)
+    eigenvectors : np.ndarray
+        Corresponding eigenvectors as columns (n, n)
+    """
+    n = A.shape[0]
+    S = A.astype(np.float64).copy()
+    V = np.eye(n, dtype=np.float64)
+
+    tol = EPSILON * n * n
+
+    for _ in range(max_iter):
+        # Compute sum of squares of off-diagonal elements (vectorized)
+        off_diag = np.triu(S, k=1)
+        off_diag_sum = np.sum(off_diag ** 2)
+
+        if off_diag_sum < tol:
+            break
+
+        # One sweep: iterate over all upper-triangle pairs
+        for p in range(n):
+            for q in range(p + 1, n):
+                if abs(S[p, q]) < EPSILON:
+                    continue
+
+                # Compute Jacobi rotation parameters
+                if abs(S[p, p] - S[q, q]) < EPSILON:
+                    theta = np.pi / 4.0
+                else:
+                    tau = (S[q, q] - S[p, p]) / (2.0 * S[p, q])
+                    if tau >= 0:
+                        t = 1.0 / (tau + np.sqrt(1.0 + tau * tau))
+                    else:
+                        t = -1.0 / (-tau + np.sqrt(1.0 + tau * tau))
+                    theta = np.arctan(t)
+
+                c = np.cos(theta)
+                s = np.sin(theta)
+
+                # Apply Givens rotation using vectorized column operations
+                # Update columns p and q of S
+                S_p = S[:, p].copy()
+                S_q = S[:, q].copy()
+                S[:, p] = c * S_p - s * S_q
+                S[:, q] = s * S_p + c * S_q
+
+                # Update rows p and q of S (symmetric)
+                S_p = S[p, :].copy()
+                S_q = S[q, :].copy()
+                S[p, :] = c * S_p - s * S_q
+                S[q, :] = s * S_p + c * S_q
+
+                # Correct the (p,q) and (q,p) elements to be exactly 0
+                S[p, q] = 0.0
+                S[q, p] = 0.0
+
+                # Accumulate eigenvectors (vectorized column update)
+                V_p = V[:, p].copy()
+                V_q = V[:, q].copy()
+                V[:, p] = c * V_p - s * V_q
+                V[:, q] = s * V_p + c * V_q
+
+    eigenvalues = np.diag(S)
+
+    # Sort in ascending order (like scipy.linalg.eigh)
+    idx = np.argsort(eigenvalues)
+    eigenvalues = eigenvalues[idx]
+    V = V[:, idx]
+
+    return eigenvalues, V
+
+
+def my_eigh_generalized(
+    A: NDArray[np.float64],
+    B: NDArray[np.float64],
+    max_iter: int = 200
+) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """
+    Solve the generalized eigenvalue problem A @ x = lambda * B @ x.
+
+    Reduces to standard form using Cholesky decomposition of B:
+        B = L @ L^T
+        L^{-1} A L^{-T} y = lambda y
+        x = L^{-T} y
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Symmetric matrix of shape (n, n)
+    B : np.ndarray
+        Symmetric positive-definite matrix of shape (n, n)
+    max_iter : int
+        Maximum Jacobi iterations
+
+    Returns
+    -------
+    eigenvalues : np.ndarray
+        Eigenvalues in ascending order (n,)
+    eigenvectors : np.ndarray
+        Generalized eigenvectors as columns (n, n)
+    """
+    n = A.shape[0]
+
+    # Regularize B to ensure positive definiteness
+    B_reg = B + EPSILON_SMALL * np.eye(n)
+
+    # Cholesky decomposition: B = L @ L^T
+    L = my_cholesky(B_reg)
+    L_inv = _invert_lower_triangular(L)
+
+    # Transform to standard eigenvalue problem
+    # C = L^{-1} A L^{-T}
+    C = L_inv @ A @ L_inv.T
+
+    # Ensure symmetry (numerical precision)
+    C = (C + C.T) / 2.0
+
+    # Solve standard eigenvalue problem
+    eigenvalues, Y = my_eigh(C, max_iter=max_iter)
+
+    # Back-transform eigenvectors: x = L^{-T} y
+    eigenvectors = L_inv.T @ Y
+
+    return eigenvalues, eigenvectors
+
+
+def my_svd(A: NDArray[np.float64],
+           max_iter: int = 200) -> Tuple[NDArray[np.float64],
+                                         NDArray[np.float64],
+                                         NDArray[np.float64]]:
+    """
+    Compute the Singular Value Decomposition A = U @ diag(s) @ Vt.
+
+    Uses eigendecomposition of A^T @ A to find V and singular values,
+    then computes U = A @ V @ diag(1/s). When m < n, uses the dual
+    trick (eigendecompose A @ A^T instead) for efficiency.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Matrix of shape (m, n)
+    max_iter : int
+        Maximum Jacobi iterations
+
+    Returns
+    -------
+    U : np.ndarray
+        Left singular vectors of shape (m, k) where k = min(m, n)
+    s : np.ndarray
+        Singular values of shape (k,), in descending order
+    Vt : np.ndarray
+        Right singular vectors (transposed) of shape (k, n)
+    """
+    m, n = A.shape
+    k = min(m, n)
+
+    if m >= n:
+        # Standard approach: eigendecompose A^T A
+        AtA = A.T @ A
+        AtA = (AtA + AtA.T) / 2.0
+        eigenvalues, V = my_eigh(AtA, max_iter=max_iter)
+
+        eigenvalues = eigenvalues[::-1]
+        V = V[:, ::-1]
+        eigenvalues = eigenvalues[:k]
+        V = V[:, :k]
+
+        s = np.sqrt(np.maximum(eigenvalues, 0.0))
+
+        U = np.zeros((m, k), dtype=np.float64)
+        for i in range(k):
+            if s[i] > EPSILON:
+                U[:, i] = (A @ V[:, i]) / s[i]
+        Vt = V.T
+    else:
+        # Dual trick: eigendecompose A A^T (smaller matrix)
+        AAt = A @ A.T
+        AAt = (AAt + AAt.T) / 2.0
+        eigenvalues, U = my_eigh(AAt, max_iter=max_iter)
+
+        eigenvalues = eigenvalues[::-1]
+        U = U[:, ::-1]
+        eigenvalues = eigenvalues[:k]
+        U = U[:, :k]
+
+        s = np.sqrt(np.maximum(eigenvalues, 0.0))
+
+        V = np.zeros((n, k), dtype=np.float64)
+        for i in range(k):
+            if s[i] > EPSILON:
+                V[:, i] = (A.T @ U[:, i]) / s[i]
+        Vt = V.T
+
+    return U, s, Vt

--- a/src/transforms/pca.py
+++ b/src/transforms/pca.py
@@ -6,10 +6,10 @@ An alternative dimensionality reduction method for EEG data.
 
 from typing import Optional
 import numpy as np
-from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from constants import DEFAULT_N_COMPONENTS_PCA
+from constants import DEFAULT_N_COMPONENTS_PCA, EPSILON
+from transforms.linalg import my_eigh
 
 
 class MyPCA(BaseEstimator, TransformerMixin):
@@ -52,26 +52,46 @@ class MyPCA(BaseEstimator, TransformerMixin):
         -------
         self : MyPCA
         """
+        n_samples, n_features = X.shape
+
         # Center the data
         self.mean_ = np.mean(X, axis=0)
         X_centered = X - self.mean_
 
-        # Compute covariance matrix
-        cov = np.dot(X_centered.T, X_centered) / (X.shape[0] - 1)
+        if n_features <= n_samples:
+            # Standard: eigendecompose the covariance matrix
+            cov = np.dot(X_centered.T, X_centered) / (n_samples - 1)
+            eigenvalues, eigenvectors = my_eigh(cov)
 
-        # Eigendecomposition
-        eigenvalues, eigenvectors = linalg.eigh(cov)
+            sorted_idx = np.argsort(eigenvalues)[::-1]
+            eigenvalues = eigenvalues[sorted_idx]
+            eigenvectors = eigenvectors[:, sorted_idx]
 
-        # Sort in descending order
-        sorted_idx = np.argsort(eigenvalues)[::-1]
-        eigenvalues = eigenvalues[sorted_idx]
-        eigenvectors = eigenvectors[:, sorted_idx]
+            self.components_ = eigenvectors[:, :self.n_components]
+        else:
+            # Dual trick: eigendecompose X X^T (n_samples x n_samples)
+            # when n_features >> n_samples, this is much faster
+            gram = np.dot(X_centered, X_centered.T) / (n_samples - 1)
+            eigenvalues, U = my_eigh(gram)
 
-        # Keep top n_components
-        self.components_ = eigenvectors[:, :self.n_components]
+            sorted_idx = np.argsort(eigenvalues)[::-1]
+            eigenvalues = eigenvalues[sorted_idx]
+            U = U[:, sorted_idx]
+
+            # Recover eigenvectors in feature space: v = X^T u / (sqrt(lambda * (n-1)))
+            components = np.zeros((n_features, min(n_samples, self.n_components)))
+            for i in range(min(n_samples, self.n_components)):
+                if eigenvalues[i] > EPSILON:
+                    v = X_centered.T @ U[:, i]
+                    v = v / (np.sqrt(eigenvalues[i] * (n_samples - 1))
+                             + EPSILON)
+                    components[:, i] = v
+            self.components_ = components[:, :self.n_components]
+
         self.explained_variance_ = eigenvalues[:self.n_components]
+        total_var = np.sum(np.maximum(eigenvalues, 0.0))
         self.explained_variance_ratio_ = (
-            self.explained_variance_ / eigenvalues.sum()
+            self.explained_variance_ / (total_var + EPSILON)
         )
 
         return self

--- a/tests/classifiers/test_nearest_centroid.py
+++ b/tests/classifiers/test_nearest_centroid.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for MyNearestCentroid classifier.
+"""
+
+import pytest
+import numpy as np
+
+
+class TestMyNearestCentroidInit:
+    """Tests for MyNearestCentroid initialization."""
+
+    def test_init_default_params(self):
+        """Test default initialization."""
+        from classifiers import MyNearestCentroid
+
+        clf = MyNearestCentroid()
+        assert clf.shrink_threshold is None
+
+    def test_init_custom_params(self):
+        """Test initialization with shrinkage."""
+        from classifiers import MyNearestCentroid
+
+        clf = MyNearestCentroid(shrink_threshold=0.5)
+        assert clf.shrink_threshold == 0.5
+
+
+class TestMyNearestCentroidFit:
+    """Tests for MyNearestCentroid.fit method."""
+
+    def test_fit_returns_self(self, random_seed):
+        """Test that fit returns self."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        result = clf.fit(X, y)
+        assert result is clf
+
+    def test_fit_creates_attributes(self, random_seed):
+        """Test that fit creates necessary attributes."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        assert hasattr(clf, 'classes_')
+        assert hasattr(clf, 'centroids_')
+        assert hasattr(clf, 'overall_centroid_')
+
+    def test_fit_classes(self, random_seed):
+        """Test that classes are correctly identified."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(30, 5)
+        y = np.array([1] * 15 + [2] * 15)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        assert len(clf.classes_) == 2
+        assert 1 in clf.classes_
+        assert 2 in clf.classes_
+
+    def test_fit_centroids_shape(self, random_seed):
+        """Test centroid shapes are correct."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 8)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        assert clf.centroids_.shape == (2, 8)
+        assert clf.overall_centroid_.shape == (8,)
+
+    def test_fit_centroid_values(self, random_seed):
+        """Test that centroids are close to expected means."""
+        from classifiers import MyNearestCentroid
+
+        n_features = 3
+        X_class1 = np.ones((10, n_features)) * 5.0
+        X_class2 = np.ones((10, n_features)) * -5.0
+        X = np.vstack([X_class1, X_class2])
+        y = np.array([1] * 10 + [2] * 10)
+
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        np.testing.assert_array_almost_equal(clf.centroids_[0], [5.0] * 3)
+        np.testing.assert_array_almost_equal(clf.centroids_[1], [-5.0] * 3)
+
+
+class TestMyNearestCentroidPredict:
+    """Tests for MyNearestCentroid.predict method."""
+
+    def test_predict_not_fitted_raises_error(self, random_seed):
+        """Test that predict raises error if not fitted."""
+        from classifiers import MyNearestCentroid
+
+        clf = MyNearestCentroid()
+        X = np.random.randn(5, 3)
+
+        with pytest.raises(RuntimeError, match="not fitted"):
+            clf.predict(X)
+
+    def test_predict_output_shape(self, random_seed):
+        """Test prediction output shape."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        preds = clf.predict(X)
+        assert preds.shape == (20,)
+
+    def test_predict_valid_labels(self, random_seed):
+        """Test that predictions are valid class labels."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        preds = clf.predict(X)
+        assert set(preds).issubset({1, 2})
+
+    def test_predict_separable_data(self, random_seed):
+        """Test perfect classification on well-separated data."""
+        from classifiers import MyNearestCentroid
+
+        X = np.vstack([
+            np.random.randn(20, 5) + 5,
+            np.random.randn(20, 5) - 5
+        ])
+        y = np.array([1] * 20 + [2] * 20)
+
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+        acc = clf.score(X, y)
+        assert acc == 1.0
+
+
+class TestMyNearestCentroidShrinkage:
+    """Tests for shrinkage regularization."""
+
+    def test_shrinkage_moves_centroids_toward_overall(self, random_seed):
+        """Test that shrinkage moves centroids toward the overall centroid."""
+        from classifiers import MyNearestCentroid
+
+        X = np.vstack([
+            np.ones((10, 3)) * 10,
+            np.ones((10, 3)) * -10
+        ])
+        y = np.array([1] * 10 + [2] * 10)
+
+        clf_no_shrink = MyNearestCentroid()
+        clf_no_shrink.fit(X, y)
+
+        clf_shrink = MyNearestCentroid(shrink_threshold=5.0)
+        clf_shrink.fit(X, y)
+
+        # With shrinkage, centroids should be closer to overall centroid (0)
+        dist_no_shrink = np.linalg.norm(
+            clf_no_shrink.centroids_ - clf_no_shrink.overall_centroid_)
+        dist_shrink = np.linalg.norm(
+            clf_shrink.centroids_ - clf_shrink.overall_centroid_)
+        assert dist_shrink < dist_no_shrink
+
+
+class TestMyNearestCentroidScore:
+    """Tests for MyNearestCentroid.score method."""
+
+    def test_score_returns_float(self, random_seed):
+        """Test that score returns a float."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        score = clf.score(X, y)
+        assert isinstance(score, float)
+
+    def test_score_between_zero_and_one(self, random_seed):
+        """Test that score is between 0 and 1."""
+        from classifiers import MyNearestCentroid
+
+        X = np.random.randn(20, 5)
+        y = np.array([1] * 10 + [2] * 10)
+        clf = MyNearestCentroid()
+        clf.fit(X, y)
+
+        score = clf.score(X, y)
+        assert 0.0 <= score <= 1.0
+
+
+class TestMyNearestCentroidSklearnCompat:
+    """Tests for sklearn compatibility."""
+
+    def test_sklearn_interface(self):
+        """Test MyNearestCentroid has sklearn interface."""
+        from classifiers import MyNearestCentroid
+
+        clf = MyNearestCentroid()
+        assert hasattr(clf, 'fit')
+        assert hasattr(clf, 'predict')
+        assert hasattr(clf, 'score')
+        assert hasattr(clf, 'get_params')
+        assert hasattr(clf, 'set_params')
+
+    def test_get_set_params(self):
+        """Test get_params and set_params."""
+        from classifiers import MyNearestCentroid
+
+        clf = MyNearestCentroid(shrink_threshold=0.3)
+        params = clf.get_params()
+        assert params['shrink_threshold'] == 0.3
+
+        clf.set_params(shrink_threshold=0.5)
+        assert clf.shrink_threshold == 0.5
+
+    def test_cross_validation(self, random_seed):
+        """Test compatibility with sklearn cross_val_score."""
+        from classifiers import MyNearestCentroid
+        from sklearn.model_selection import cross_val_score
+
+        X = np.vstack([
+            np.random.randn(30, 5) + 3,
+            np.random.randn(30, 5) - 3
+        ])
+        y = np.array([1] * 30 + [2] * 30)
+
+        scores = cross_val_score(MyNearestCentroid(), X, y, cv=3)
+        assert len(scores) == 3
+        assert all(0 <= s <= 1 for s in scores)

--- a/tests/features/test_wavelet.py
+++ b/tests/features/test_wavelet.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for WaveletExtractor class.
+"""
+
+import numpy as np
+
+from constants import EEG_SAMPLING_RATE
+
+
+class TestWaveletExtractorInit:
+    """Tests for WaveletExtractor initialization."""
+
+    def test_init_default_params(self):
+        """Test WaveletExtractor initialization with default parameters."""
+        from features import WaveletExtractor
+
+        extractor = WaveletExtractor()
+        assert extractor.fs == EEG_SAMPLING_RATE
+        assert 'mu' in extractor.freq_bands
+        assert 'beta' in extractor.freq_bands
+        assert extractor.n_scales_per_band == 5
+        assert extractor.omega0 == 5.0
+
+    def test_init_custom_params(self):
+        """Test WaveletExtractor with custom parameters."""
+        from features import WaveletExtractor
+
+        custom_bands = {'alpha': (8, 13)}
+        extractor = WaveletExtractor(
+            fs=250.0, freq_bands=custom_bands,
+            n_scales_per_band=10, omega0=6.0)
+
+        assert extractor.fs == 250.0
+        assert extractor.freq_bands == custom_bands
+        assert extractor.n_scales_per_band == 10
+        assert extractor.omega0 == 6.0
+
+
+class TestWaveletExtractorFit:
+    """Tests for WaveletExtractor.fit method."""
+
+    def test_fit_returns_self(self, synthetic_eeg_data):
+        """Test that fit returns self."""
+        from features import WaveletExtractor
+
+        X, y = synthetic_eeg_data
+        extractor = WaveletExtractor()
+        result = extractor.fit(X, y)
+        assert result is extractor
+
+
+class TestWaveletExtractorTransform:
+    """Tests for WaveletExtractor.transform method."""
+
+    def test_transform_output_shape(self, synthetic_eeg_data, n_epochs,
+                                    n_channels):
+        """Test WaveletExtractor output shape."""
+        from features import WaveletExtractor
+
+        X, y = synthetic_eeg_data
+        extractor = WaveletExtractor()
+        X_wav = extractor.fit_transform(X)
+
+        n_bands = len(extractor.freq_bands)
+        expected_shape = (n_epochs, n_channels * n_bands)
+        assert X_wav.shape == expected_shape
+
+    def test_transform_no_nan(self, synthetic_eeg_data):
+        """Test that transform does not produce NaN values."""
+        from features import WaveletExtractor
+
+        X, y = synthetic_eeg_data
+        extractor = WaveletExtractor()
+        X_wav = extractor.fit_transform(X)
+        assert not np.isnan(X_wav).any()
+
+    def test_transform_positive_values(self, synthetic_eeg_data):
+        """Test that wavelet energy values are non-negative."""
+        from features import WaveletExtractor
+
+        X, y = synthetic_eeg_data
+        extractor = WaveletExtractor()
+        X_wav = extractor.fit_transform(X)
+        assert np.all(X_wav >= 0)
+
+    def test_transform_custom_bands(self, small_synthetic_data):
+        """Test with custom frequency bands."""
+        from features import WaveletExtractor
+
+        X, y = small_synthetic_data
+        custom_bands = {'theta': (4, 8), 'alpha': (8, 13), 'beta': (13, 30)}
+        extractor = WaveletExtractor(freq_bands=custom_bands)
+        X_wav = extractor.fit_transform(X)
+
+        n_channels = X.shape[1]
+        assert X_wav.shape == (X.shape[0], n_channels * 3)
+
+    def test_transform_different_scales(self, small_synthetic_data):
+        """Test with different number of scales per band."""
+        from features import WaveletExtractor
+
+        X, y = small_synthetic_data
+        extractor = WaveletExtractor(n_scales_per_band=3)
+        X_wav = extractor.fit_transform(X)
+
+        assert X_wav.shape[0] == X.shape[0]
+        assert not np.isnan(X_wav).any()
+
+
+class TestWaveletExtractorSklearnCompat:
+    """Tests for WaveletExtractor sklearn compatibility."""
+
+    def test_sklearn_interface(self):
+        """Test WaveletExtractor has sklearn interface methods."""
+        from features import WaveletExtractor
+
+        extractor = WaveletExtractor()
+        assert hasattr(extractor, 'fit')
+        assert hasattr(extractor, 'transform')
+        assert hasattr(extractor, 'fit_transform')
+        assert hasattr(extractor, 'get_params')
+        assert hasattr(extractor, 'set_params')
+
+    def test_get_set_params(self):
+        """Test get_params and set_params."""
+        from features import WaveletExtractor
+
+        extractor = WaveletExtractor(fs=160.0, n_scales_per_band=5)
+        params = extractor.get_params()
+
+        assert params['fs'] == 160.0
+        assert params['n_scales_per_band'] == 5
+
+        extractor.set_params(n_scales_per_band=10)
+        assert extractor.n_scales_per_band == 10
+
+
+class TestMorletWavelet:
+    """Tests for the Morlet wavelet implementation."""
+
+    def test_morlet_shape(self):
+        """Test Morlet wavelet output shape."""
+        from features import _morlet_wavelet
+
+        wavelet = _morlet_wavelet(n_points=256, scale=5.0, fs=160.0)
+        assert wavelet.shape == (256,)
+
+    def test_morlet_is_complex(self):
+        """Test that Morlet wavelet is complex-valued."""
+        from features import _morlet_wavelet
+
+        wavelet = _morlet_wavelet(n_points=256, scale=5.0, fs=160.0)
+        assert np.iscomplexobj(wavelet)
+
+    def test_morlet_finite(self):
+        """Test that Morlet wavelet has no NaN or Inf values."""
+        from features import _morlet_wavelet
+
+        wavelet = _morlet_wavelet(n_points=256, scale=5.0, fs=160.0)
+        assert np.all(np.isfinite(wavelet))
+
+
+class TestCWT:
+    """Tests for the custom CWT implementation."""
+
+    def test_cwt_output_shape(self):
+        """Test CWT output shape."""
+        from features import _cwt_morlet
+
+        x = np.random.randn(160)
+        scales = np.array([2.0, 4.0, 8.0])
+        coeffs = _cwt_morlet(x, scales, fs=160.0)
+        assert coeffs.shape == (3, 160)
+
+    def test_cwt_positive_magnitude(self):
+        """Test that CWT magnitude coefficients are non-negative."""
+        from features import _cwt_morlet
+
+        x = np.random.randn(160)
+        scales = np.array([2.0, 4.0, 8.0])
+        coeffs = _cwt_morlet(x, scales, fs=160.0)
+        assert np.all(coeffs >= 0)
+
+    def test_cwt_no_nan(self):
+        """Test that CWT produces no NaN values."""
+        from features import _cwt_morlet
+
+        x = np.random.randn(160)
+        scales = np.array([2.0, 4.0, 8.0])
+        coeffs = _cwt_morlet(x, scales, fs=160.0)
+        assert not np.isnan(coeffs).any()
+
+    def test_cwt_sinusoidal_signal(self):
+        """Test CWT detects known frequency in sinusoidal signal."""
+        from features import _cwt_morlet, _freq_to_scale
+
+        fs = 160.0
+        t = np.arange(0, 1.0, 1.0 / fs)
+        freq_target = 10.0  # 10 Hz signal
+        x = np.sin(2 * np.pi * freq_target * t)
+
+        # Scales for frequencies around 10 Hz and 30 Hz
+        scale_10 = _freq_to_scale(10.0, fs)
+        scale_30 = _freq_to_scale(30.0, fs)
+        scales = np.array([scale_10, scale_30])
+
+        coeffs = _cwt_morlet(x, scales, fs=fs)
+
+        # Energy at 10 Hz should be higher than at 30 Hz
+        energy_10 = np.mean(coeffs[0, :] ** 2)
+        energy_30 = np.mean(coeffs[1, :] ** 2)
+        assert energy_10 > energy_30

--- a/tests/pipeline/test_bonus_pipelines.py
+++ b/tests/pipeline/test_bonus_pipelines.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for bonus pipelines (wavelet and custom classifier).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from sklearn.pipeline import Pipeline
+
+
+class TestBuildWaveletLdaPipeline:
+    """Tests for build_wavelet_lda_pipeline function."""
+
+    def test_returns_pipeline(self):
+        """Test that build_wavelet_lda_pipeline returns Pipeline."""
+        from pipeline import build_wavelet_lda_pipeline
+
+        pipeline = build_wavelet_lda_pipeline()
+        assert isinstance(pipeline, Pipeline)
+
+    def test_has_expected_steps(self):
+        """Test pipeline has wavelet, scaler, and LDA steps."""
+        from pipeline import build_wavelet_lda_pipeline
+
+        pipeline = build_wavelet_lda_pipeline()
+        steps = dict(pipeline.steps)
+        assert 'wavelet' in steps
+        assert 'scaler' in steps
+        assert 'lda' in steps
+
+    def test_fs_parameter(self):
+        """Test sampling frequency parameter."""
+        from pipeline import build_wavelet_lda_pipeline
+
+        pipeline = build_wavelet_lda_pipeline(fs=250.0)
+        wavelet = dict(pipeline.steps)['wavelet']
+        assert wavelet.fs == 250.0
+
+    def test_n_scales_parameter(self):
+        """Test n_scales_per_band parameter."""
+        from pipeline import build_wavelet_lda_pipeline
+
+        pipeline = build_wavelet_lda_pipeline(n_scales_per_band=10)
+        wavelet = dict(pipeline.steps)['wavelet']
+        assert wavelet.n_scales_per_band == 10
+
+    def test_fit_predict(self, small_synthetic_data):
+        """Test pipeline can fit and predict."""
+        from pipeline import build_wavelet_lda_pipeline
+
+        X, y = small_synthetic_data
+        pipeline = build_wavelet_lda_pipeline()
+        pipeline.fit(X, y)
+        predictions = pipeline.predict(X)
+
+        assert len(predictions) == len(y)
+        assert set(predictions).issubset(set(y))
+
+
+class TestBuildWaveletCustomPipeline:
+    """Tests for build_wavelet_custom_pipeline function."""
+
+    def test_returns_pipeline(self):
+        """Test that build_wavelet_custom_pipeline returns Pipeline."""
+        from pipeline import build_wavelet_custom_pipeline
+
+        pipeline = build_wavelet_custom_pipeline()
+        assert isinstance(pipeline, Pipeline)
+
+    def test_has_expected_steps(self):
+        """Test pipeline has wavelet, scaler, and custom classifier steps."""
+        from pipeline import build_wavelet_custom_pipeline
+
+        pipeline = build_wavelet_custom_pipeline()
+        steps = dict(pipeline.steps)
+        assert 'wavelet' in steps
+        assert 'scaler' in steps
+        assert 'clf' in steps
+
+    def test_shrinkage_parameter(self):
+        """Test shrinkage parameter passes through."""
+        from pipeline import build_wavelet_custom_pipeline
+
+        pipeline = build_wavelet_custom_pipeline(shrink_threshold=0.5)
+        clf = dict(pipeline.steps)['clf']
+        assert clf.shrink_threshold == 0.5
+
+    def test_fit_predict(self, small_synthetic_data):
+        """Test pipeline can fit and predict."""
+        from pipeline import build_wavelet_custom_pipeline
+
+        X, y = small_synthetic_data
+        pipeline = build_wavelet_custom_pipeline()
+        pipeline.fit(X, y)
+        predictions = pipeline.predict(X)
+
+        assert len(predictions) == len(y)
+        assert set(predictions).issubset(set(y))
+
+
+class TestBuildCspCustomPipeline:
+    """Tests for build_csp_custom_pipeline function."""
+
+    def test_returns_pipeline(self):
+        """Test that build_csp_custom_pipeline returns Pipeline."""
+        from pipeline import build_csp_custom_pipeline
+
+        pipeline = build_csp_custom_pipeline()
+        assert isinstance(pipeline, Pipeline)
+
+    def test_has_expected_steps(self):
+        """Test pipeline has CSP, scaler, and custom classifier steps."""
+        from pipeline import build_csp_custom_pipeline
+
+        pipeline = build_csp_custom_pipeline()
+        steps = dict(pipeline.steps)
+        assert 'csp' in steps
+        assert 'scaler' in steps
+        assert 'clf' in steps
+
+    def test_n_components_parameter(self):
+        """Test n_components passes through to CSP."""
+        from pipeline import build_csp_custom_pipeline
+
+        pipeline = build_csp_custom_pipeline(n_components=8)
+        csp = dict(pipeline.steps)['csp']
+        assert csp.n_components == 8
+
+    def test_fit_predict(self, small_synthetic_data):
+        """Test pipeline can fit and predict."""
+        from pipeline import build_csp_custom_pipeline
+
+        X, y = small_synthetic_data
+        pipeline = build_csp_custom_pipeline(n_components=4)
+        pipeline.fit(X, y)
+        predictions = pipeline.predict(X)
+
+        assert len(predictions) == len(y)
+        assert set(predictions).issubset(set(y))
+
+
+class TestNewPipelinesInRegistry:
+    """Tests for new pipelines in the registry."""
+
+    def test_wavelet_lda_in_list(self):
+        """Test wavelet_lda is in pipeline list."""
+        from pipeline import list_pipelines
+
+        assert 'wavelet_lda' in list_pipelines()
+
+    def test_wavelet_custom_in_list(self):
+        """Test wavelet_custom is in pipeline list."""
+        from pipeline import list_pipelines
+
+        assert 'wavelet_custom' in list_pipelines()
+
+    def test_csp_custom_in_list(self):
+        """Test csp_custom is in pipeline list."""
+        from pipeline import list_pipelines
+
+        assert 'csp_custom' in list_pipelines()
+
+    def test_get_pipeline_wavelet_lda(self):
+        """Test get_pipeline returns wavelet_lda."""
+        from pipeline import get_pipeline
+
+        pipeline = get_pipeline('wavelet_lda')
+        assert isinstance(pipeline, Pipeline)
+
+    def test_get_pipeline_wavelet_custom(self):
+        """Test get_pipeline returns wavelet_custom."""
+        from pipeline import get_pipeline
+
+        pipeline = get_pipeline('wavelet_custom')
+        assert isinstance(pipeline, Pipeline)
+
+    def test_get_pipeline_csp_custom(self):
+        """Test get_pipeline returns csp_custom."""
+        from pipeline import get_pipeline
+
+        pipeline = get_pipeline('csp_custom')
+        assert isinstance(pipeline, Pipeline)
+
+    def test_total_pipeline_count(self):
+        """Test that we now have 10 pipelines."""
+        from pipeline import list_pipelines
+
+        assert len(list_pipelines()) == 10

--- a/tests/pipeline/test_factory.py
+++ b/tests/pipeline/test_factory.py
@@ -22,17 +22,18 @@ class TestListPipelines:
 
         result = list_pipelines()
         expected = ['csp_lda', 'csp_svm', 'csp_lr', 'csp_rf',
-                    'psd_lda', 'bandpower_lda', 'flat_pca_lda']
+                    'psd_lda', 'bandpower_lda', 'flat_pca_lda',
+                    'wavelet_lda', 'wavelet_custom', 'csp_custom']
 
         for name in expected:
             assert name in result
 
-    def test_returns_seven_pipelines(self):
-        """Test that exactly 7 pipelines are available."""
+    def test_returns_ten_pipelines(self):
+        """Test that exactly 10 pipelines are available."""
         from pipeline import list_pipelines
 
         result = list_pipelines()
-        assert len(result) == 7
+        assert len(result) == 10
 
 
 class TestGetPipeline:
@@ -43,7 +44,8 @@ class TestGetPipeline:
         from pipeline import get_pipeline
 
         for name in ['csp_lda', 'csp_svm', 'csp_lr', 'csp_rf',
-                     'psd_lda', 'bandpower_lda', 'flat_pca_lda']:
+                     'psd_lda', 'bandpower_lda', 'flat_pca_lda',
+                     'wavelet_lda', 'wavelet_custom', 'csp_custom']:
             pipeline = get_pipeline(name)
             assert isinstance(pipeline, Pipeline)
 

--- a/tests/transforms/test_linalg.py
+++ b/tests/transforms/test_linalg.py
@@ -1,0 +1,271 @@
+"""
+Unit tests for custom linear algebra module.
+"""
+
+import pytest
+import numpy as np
+
+
+class TestMyCovariance:
+    """Tests for my_covariance function."""
+
+    def test_covariance_shape(self, random_seed):
+        """Test output shape of covariance matrix."""
+        from transforms.linalg import my_covariance
+
+        X = np.random.randn(5, 20)
+        cov = my_covariance(X, rowvar=True)
+        assert cov.shape == (5, 5)
+
+    def test_covariance_symmetric(self, random_seed):
+        """Test that covariance matrix is symmetric."""
+        from transforms.linalg import my_covariance
+
+        X = np.random.randn(10, 50)
+        cov = my_covariance(X, rowvar=True)
+        np.testing.assert_array_almost_equal(cov, cov.T)
+
+    def test_covariance_matches_numpy(self, random_seed):
+        """Test that custom covariance matches numpy.cov."""
+        from transforms.linalg import my_covariance
+
+        X = np.random.randn(5, 20)
+        cov_custom = my_covariance(X, rowvar=True)
+        cov_numpy = np.cov(X)
+        np.testing.assert_array_almost_equal(cov_custom, cov_numpy, decimal=10)
+
+    def test_covariance_rowvar_false(self, random_seed):
+        """Test covariance with rowvar=False (columns are variables)."""
+        from transforms.linalg import my_covariance
+
+        X = np.random.randn(20, 5)
+        cov_custom = my_covariance(X, rowvar=False)
+        cov_numpy = np.cov(X, rowvar=False)
+        np.testing.assert_array_almost_equal(cov_custom, cov_numpy, decimal=10)
+
+    def test_covariance_positive_semidefinite(self, random_seed):
+        """Test that covariance matrix is positive semi-definite."""
+        from transforms.linalg import my_covariance
+
+        X = np.random.randn(5, 30)
+        cov = my_covariance(X, rowvar=True)
+        eigenvalues = np.linalg.eigvalsh(cov)
+        assert np.all(eigenvalues >= -1e-10)
+
+
+class TestMyCholesky:
+    """Tests for my_cholesky function."""
+
+    def test_cholesky_reconstruction(self, random_seed):
+        """Test that L @ L.T reconstructs the original matrix."""
+        from transforms.linalg import my_cholesky
+
+        A = np.random.randn(5, 5)
+        A = A @ A.T + 0.1 * np.eye(5)  # positive definite
+        L = my_cholesky(A)
+        np.testing.assert_array_almost_equal(L @ L.T, A)
+
+    def test_cholesky_lower_triangular(self, random_seed):
+        """Test that L is lower triangular."""
+        from transforms.linalg import my_cholesky
+
+        A = np.random.randn(4, 4)
+        A = A @ A.T + np.eye(4)
+        L = my_cholesky(A)
+
+        for i in range(4):
+            for j in range(i + 1, 4):
+                assert abs(L[i, j]) < 1e-15
+
+    def test_cholesky_positive_diagonal(self, random_seed):
+        """Test that diagonal elements of L are positive."""
+        from transforms.linalg import my_cholesky
+
+        A = np.random.randn(6, 6)
+        A = A @ A.T + np.eye(6)
+        L = my_cholesky(A)
+        assert np.all(np.diag(L) > 0)
+
+    def test_cholesky_not_positive_definite(self):
+        """Test that non-positive-definite matrix raises ValueError."""
+        from transforms.linalg import my_cholesky
+
+        A = np.array([[-1, 0], [0, 1]], dtype=np.float64)
+        with pytest.raises(ValueError, match="not positive definite"):
+            my_cholesky(A)
+
+
+class TestMyEigh:
+    """Tests for my_eigh Jacobi eigenvalue algorithm."""
+
+    def test_eigh_eigenvalues_correct(self, random_seed):
+        """Test that eigenvalues satisfy A @ v = lambda * v."""
+        from transforms.linalg import my_eigh
+
+        A = np.random.randn(6, 6)
+        A = A @ A.T  # symmetric
+        eigenvalues, eigenvectors = my_eigh(A)
+
+        for i in range(6):
+            residual = A @ eigenvectors[:, i] - eigenvalues[i] * eigenvectors[:, i]
+            assert np.linalg.norm(residual) < 1e-6
+
+    def test_eigh_ascending_order(self, random_seed):
+        """Test that eigenvalues are in ascending order."""
+        from transforms.linalg import my_eigh
+
+        A = np.random.randn(8, 8)
+        A = A @ A.T
+        eigenvalues, _ = my_eigh(A)
+
+        for i in range(len(eigenvalues) - 1):
+            assert eigenvalues[i] <= eigenvalues[i + 1] + 1e-10
+
+    def test_eigh_orthogonal_eigenvectors(self, random_seed):
+        """Test that eigenvectors are orthogonal."""
+        from transforms.linalg import my_eigh
+
+        A = np.random.randn(5, 5)
+        A = A @ A.T
+        _, eigenvectors = my_eigh(A)
+
+        dot_product = eigenvectors.T @ eigenvectors
+        np.testing.assert_array_almost_equal(dot_product, np.eye(5), decimal=6)
+
+    def test_eigh_matches_numpy(self, random_seed):
+        """Test that eigenvalues match numpy's implementation."""
+        from transforms.linalg import my_eigh
+
+        A = np.random.randn(6, 6)
+        A = A @ A.T
+        eigenvalues_custom, _ = my_eigh(A)
+        eigenvalues_numpy = np.linalg.eigvalsh(A)
+
+        np.testing.assert_array_almost_equal(
+            eigenvalues_custom, eigenvalues_numpy, decimal=6)
+
+    def test_eigh_diagonal_matrix(self):
+        """Test eigendecomposition of a diagonal matrix."""
+        from transforms.linalg import my_eigh
+
+        A = np.diag([3.0, 1.0, 4.0, 1.5])
+        eigenvalues, _ = my_eigh(A)
+        expected = np.array([1.0, 1.5, 3.0, 4.0])
+        np.testing.assert_array_almost_equal(eigenvalues, expected)
+
+    def test_eigh_identity_matrix(self):
+        """Test eigendecomposition of identity matrix."""
+        from transforms.linalg import my_eigh
+
+        A = np.eye(4)
+        eigenvalues, eigenvectors = my_eigh(A)
+        np.testing.assert_array_almost_equal(eigenvalues, np.ones(4))
+
+
+class TestMyEighGeneralized:
+    """Tests for my_eigh_generalized function."""
+
+    def test_generalized_eigenvalues_correct(self, random_seed):
+        """Test that A @ v = lambda * B @ v."""
+        from transforms.linalg import my_eigh_generalized
+
+        A = np.random.randn(5, 5)
+        A = A @ A.T
+        B = np.random.randn(5, 5)
+        B = B @ B.T + 0.1 * np.eye(5)
+
+        eigenvalues, eigenvectors = my_eigh_generalized(A, B)
+
+        for i in range(5):
+            lhs = A @ eigenvectors[:, i]
+            rhs = eigenvalues[i] * B @ eigenvectors[:, i]
+            if np.linalg.norm(eigenvectors[:, i]) > 0.01:
+                residual = np.linalg.norm(lhs - rhs)
+                scale = np.linalg.norm(lhs) + 1e-10
+                assert residual / scale < 0.05
+
+    def test_generalized_ascending_order(self, random_seed):
+        """Test that generalized eigenvalues are in ascending order."""
+        from transforms.linalg import my_eigh_generalized
+
+        A = np.random.randn(4, 4)
+        A = A @ A.T
+        B = np.random.randn(4, 4)
+        B = B @ B.T + 0.5 * np.eye(4)
+
+        eigenvalues, _ = my_eigh_generalized(A, B)
+
+        for i in range(len(eigenvalues) - 1):
+            assert eigenvalues[i] <= eigenvalues[i + 1] + 1e-6
+
+
+class TestMySVD:
+    """Tests for my_svd function."""
+
+    def test_svd_reconstruction(self, random_seed):
+        """Test that U @ diag(s) @ Vt reconstructs A."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(5, 3)
+        U, s, Vt = my_svd(A)
+        A_reconstructed = U @ np.diag(s) @ Vt
+        np.testing.assert_array_almost_equal(A, A_reconstructed, decimal=6)
+
+    def test_svd_singular_values_nonnegative(self, random_seed):
+        """Test that singular values are non-negative."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(4, 6)
+        _, s, _ = my_svd(A)
+        assert np.all(s >= -1e-10)
+
+    def test_svd_singular_values_descending(self, random_seed):
+        """Test that singular values are in descending order."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(5, 4)
+        _, s, _ = my_svd(A)
+
+        for i in range(len(s) - 1):
+            assert s[i] >= s[i + 1] - 1e-10
+
+    def test_svd_orthogonal_U(self, random_seed):
+        """Test that U has orthonormal columns."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(6, 4)
+        U, _, _ = my_svd(A)
+        dot = U.T @ U
+        np.testing.assert_array_almost_equal(dot, np.eye(4), decimal=6)
+
+    def test_svd_orthogonal_Vt(self, random_seed):
+        """Test that Vt has orthonormal rows."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(6, 4)
+        _, _, Vt = my_svd(A)
+        dot = Vt @ Vt.T
+        np.testing.assert_array_almost_equal(dot, np.eye(4), decimal=6)
+
+    def test_svd_tall_matrix(self, random_seed):
+        """Test SVD with m > n."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(8, 3)
+        U, s, Vt = my_svd(A)
+        assert U.shape == (8, 3)
+        assert s.shape == (3,)
+        assert Vt.shape == (3, 3)
+
+    def test_svd_wide_matrix(self, random_seed):
+        """Test SVD with m < n (dual trick path)."""
+        from transforms.linalg import my_svd
+
+        A = np.random.randn(3, 8)
+        U, s, Vt = my_svd(A)
+        assert U.shape == (3, 3)
+        assert s.shape == (3,)
+        assert Vt.shape == (3, 8)
+
+        A_reconstructed = U @ np.diag(s) @ Vt
+        np.testing.assert_array_almost_equal(A, A_reconstructed, decimal=6)

--- a/uv.lock
+++ b/uv.lock
@@ -37,12 +37,111 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/88/b7df6050bf18fdcfb7046286c6535cabbdd2064a3440fca3f069d319c16e/numpy-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:444be170853f1f9d528428eceb55f12918e4fda5d8805480f36a002f1415e09b", size = 16663092, upload-time = "2026-01-31T23:12:04.521Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/1fee4329abc705a469a4afe6e69b1ef7e915117747886327104a8493a955/numpy-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1240d50adff70c2a88217698ca844723068533f3f5c5fa6ee2e3220e3bdb000", size = 14698770, upload-time = "2026-01-31T23:12:06.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0b/f9e49ba6c923678ad5bc38181c08ac5e53b7a5754dbca8e581aa1a56b1ff/numpy-2.4.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:7cdde6de52fb6664b00b056341265441192d1291c130e99183ec0d4b110ff8b1", size = 5208562, upload-time = "2026-01-31T23:12:09.632Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/12/d7de8f6f53f9bb76997e5e4c069eda2051e3fe134e9181671c4391677bb2/numpy-2.4.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:cda077c2e5b780200b6b3e09d0b42205a3d1c68f30c6dceb90401c13bff8fe74", size = 6543710, upload-time = "2026-01-31T23:12:11.969Z" },
+    { url = "https://files.pythonhosted.org/packages/09/63/c66418c2e0268a31a4cf8a8b512685748200f8e8e8ec6c507ce14e773529/numpy-2.4.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d30291931c915b2ab5717c2974bb95ee891a1cf22ebc16a8006bd59cd210d40a", size = 15677205, upload-time = "2026-01-31T23:12:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6c/7f237821c9642fb2a04d2f1e88b4295677144ca93285fd76eff3bcba858d/numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba37bc29d4d85761deed3954a1bc62be7cf462b9510b51d367b769a8c8df325", size = 16611738, upload-time = "2026-01-31T23:12:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/39c4cdda9f019b609b5c473899d87abff092fc908cfe4d1ecb2fcff453b0/numpy-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b2f0073ed0868db1dcd86e052d37279eef185b9c8db5bf61f30f46adac63c909", size = 17028888, upload-time = "2026-01-31T23:12:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/e84bb64bdfea967cc10950d71090ec2d84b49bc691df0025dddb7c26e8e3/numpy-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7f54844851cdb630ceb623dcec4db3240d1ac13d4990532446761baede94996a", size = 18339556, upload-time = "2026-01-31T23:12:21.816Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f5/954a291bc1192a27081706862ac62bb5920fbecfbaa302f64682aa90beed/numpy-2.4.2-cp314-cp314-win32.whl", hash = "sha256:12e26134a0331d8dbd9351620f037ec470b7c75929cb8a1537f6bfe411152a1a", size = 6006899, upload-time = "2026-01-31T23:12:24.14Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cb/eff72a91b2efdd1bc98b3b8759f6a1654aa87612fc86e3d87d6fe4f948c4/numpy-2.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:068cdb2d0d644cdb45670810894f6a0600797a69c05f1ac478e8d31670b8ee75", size = 12443072, upload-time = "2026-01-31T23:12:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/62726948db36a56428fce4ba80a115716dc4fad6a3a4352487f8bb950966/numpy-2.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ed0be1ee58eef41231a5c943d7d1375f093142702d5723ca2eb07db9b934b05", size = 10494886, upload-time = "2026-01-31T23:12:28.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/ee93744f1e0661dc267e4b21940870cabfae187c092e1433b77b09b50ac4/numpy-2.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98f16a80e917003a12c0580f97b5f875853ebc33e2eaa4bccfc8201ac6869308", size = 14818567, upload-time = "2026-01-31T23:12:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/6535212add7d76ff938d8bdc654f53f88d35cddedf807a599e180dcb8e66/numpy-2.4.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:20abd069b9cda45874498b245c8015b18ace6de8546bf50dfa8cea1696ed06ef", size = 5328372, upload-time = "2026-01-31T23:12:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/c48f0a035725f925634bf6b8994253b43f2047f6778a54147d7e213bc5a7/numpy-2.4.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e98c97502435b53741540a5717a6749ac2ada901056c7db951d33e11c885cc7d", size = 6649306, upload-time = "2026-01-31T23:12:34.797Z" },
+    { url = "https://files.pythonhosted.org/packages/81/05/7c73a9574cd4a53a25907bad38b59ac83919c0ddc8234ec157f344d57d9a/numpy-2.4.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6cad4e82cb893db4b69105c604d805e0c3ce11501a55b5e9f9083b47d2ffe8", size = 15722394, upload-time = "2026-01-31T23:12:36.565Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fa/4de10089f21fc7d18442c4a767ab156b25c2a6eaf187c0db6d9ecdaeb43f/numpy-2.4.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e4424677ce4b47fe73c8b5556d876571f7c6945d264201180db2dc34f676ab5", size = 16653343, upload-time = "2026-01-31T23:12:39.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/d33e4ffc857f3763a57aa85650f2e82486832d7492280ac21ba9efda80da/numpy-2.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2b8f157c8a6f20eb657e240f8985cc135598b2b46985c5bccbde7616dc9c6b1e", size = 17078045, upload-time = "2026-01-31T23:12:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/54bdb43b6225badbea6389fa038c4ef868c44f5890f95dd530a218706da3/numpy-2.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5daf6f3914a733336dab21a05cdec343144600e964d2fcdabaac0c0269874b2a", size = 18380024, upload-time = "2026-01-31T23:12:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
+    { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
+    { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -61,15 +160,91 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
 name = "total-perspective-vortex"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "numpy" },
+    { name = "pytest" },
     { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.5" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.4.2" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "scikit-learn", specifier = ">=1.8.0" },
+    { name = "scipy", specifier = ">=1.17.1" },
+]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
Implement three bonus features for the EEG BCI project:

1. Wavelet Transform (CWT): Custom Morlet wavelet and FFT-based Continuous Wavelet Transform for time-frequency feature extraction from EEG signals. WaveletExtractor computes energy in mu/beta bands.

2. Custom Classifier: MyNearestCentroid classifier with optional shrinkage regularization. Computes class centroids and classifies by minimum Euclidean distance. Fully sklearn-compatible.

3. Custom Linear Algebra: Hand-coded implementations replacing scipy:
   - Jacobi eigenvalue algorithm for symmetric matrices (my_eigh)
   - Cholesky decomposition (my_cholesky)
   - Generalized eigenvalue solver via Cholesky reduction
   - SVD via eigendecomposition with dual trick for wide matrices
   - Covariance matrix computation from scratch CSP and PCA now use these custom implementations.

New pipelines: wavelet_lda, wavelet_custom, csp_custom (10 total). 184 tests pass, flake8 and mypy clean.

https://claude.ai/code/session_01BWQcQ5cE8XynZUc7meqgiN